### PR TITLE
Removed newline requirement for comments

### DIFF
--- a/GenericConfig.sublime-syntax
+++ b/GenericConfig.sublime-syntax
@@ -29,7 +29,7 @@ contexts:
       scope: constant.other.genconfig
 
     # One line comment
-    - match: (?:(?:^\s*)|\s+)(?:(#.*\n)|(--\s+.*\n)|(\/\/.*\n))$
+    - match: (?:(?:^\s*)|\s+)(?:(#.*)|(--\s+.*)|(\/\/.*))$
       captures:
         1: comment.line.number-sign.genconfig
         2: comment.line.double-dash.genconfig
@@ -37,7 +37,7 @@ contexts:
       scope: meta.comment.genconfig
 
     # ; one line comment
-    - match: (?:(?:^\s*)|(?:^.+\s+))(;.*\n)$
+    - match: (?:(?:^\s*)|(?:^.+\s+))(;.*)$
       scope: meta.comment.genconfig
       captures:
         1: comment.line.number-sign.genconfig


### PR DESCRIPTION
Fixed not recognizing comments on the last line of a file without a line below it.