### PR TITLE
file extension modifications

### DIFF
--- a/GenericConfig.sublime-syntax
+++ b/GenericConfig.sublime-syntax
@@ -8,19 +8,12 @@ file_extensions:
   - config
   - ini
   - pro
-  - mak
-  - mk
   - Doxyfile
   - inputrc
   - .inputrc
   - dircolors
   - .dircolors
-  - gitmodules
-  - .gitmodules
-  - gitignore
-  - .gitignore
-  - gitattributes
-  - .gitattributes
+  - service
 scope: source.genconfig
 contexts:
   main:


### PR DESCRIPTION
### Summary
This PR updates the file extensions associated with the GenericConfig syntax.

### Changes
- Added support for `.service` files (commonly used for service/unit definitions)
- Removed `.git` and `.mak` extensions

### Rationale
- `.service` files are configuration-oriented and fit well within the scope of this package.
- `.git` and `.mak` files are already handled by dedicated Sublime Text packages, so removing them avoids overlapping responsibilities and potential conflicts.

This keeps the package focused on generic configuration formats while deferring specialized syntaxes to purpose-built packages.
